### PR TITLE
Fixed Exceed Maximum length of field 'data'

### DIFF
--- a/lib/OA/Dll/Banner.php
+++ b/lib/OA/Dll/Banner.php
@@ -477,7 +477,7 @@ class OA_Dll_Banner extends OA_Dll
         if (!$this->checkStructureRequiredStringField($oTargeting,  'logical', 255) ||
             !$this->checkStructureRequiredStringField($oTargeting,  'type', 255) ||
             !$this->checkStructureRequiredStringField($oTargeting,  'comparison', 255) ||
-            !$this->checkStructureNotRequiredStringField($oTargeting,  'data', 255)) {
+            !$this->checkStructureNotRequiredStringField($oTargeting,  'data')) {
 
             return false;
         }


### PR DESCRIPTION
Using xml_rpc for revive an error occurs when try to save $oTargeting for a banner. Because Exceed Maximum(255) length of field 'data'
